### PR TITLE
Set API host location via the environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # data-dot-food catalog browser change history
 
+## 0.2.0 - 2020-03-11
+
+- Fix for GH-42, in which we isolate context-dependent config
+  state, such as the hostname of the API to use, in environment
+  variables to make it easier to configure the app in a docker
+  container. In addition, the app will now error if the API
+  host env var is not set.
+
 ## 2019-11-19
 
 - Merges cairn-catalog-browser assets and functionality with the data-catalog-browser

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Version
+  MAJOR = 0
+  MINOR = 2
+  PATCH = 0
+  VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
+end

--- a/app/services/catalog_api.rb
+++ b/app/services/catalog_api.rb
@@ -2,7 +2,6 @@
 
 # Service wrapper for the catalog API
 class CatalogApi
-  DEFAULT_API_HOST = 'http://localhost:8080'
   DATASET_API_ROOT = '/catalog/data/dataset'
 
   attr_reader :api
@@ -63,10 +62,12 @@ class CatalogApi
   end
 
   def api_host
-    if defined?(Rails) && defined?(Rails.application.config.api_host)
-      Rails.application.config.api_host
-    else
-      DEFAULT_API_HOST
+    unless defined?(Rails) &&
+      Rails.application.config.api_host &&
+      !Rails.application.config.api_host.empty?
+      raise 'Environment variable FSA_DATA_DOT_FOOD_API_HOST is not defined'
     end
+
+    Rails.application.config.api_host
   end
 end

--- a/app/services/catalog_api.rb
+++ b/app/services/catalog_api.rb
@@ -65,7 +65,7 @@ class CatalogApi
     unless defined?(Rails) &&
       Rails.application.config.api_host &&
       !Rails.application.config.api_host.empty?
-      raise 'Environment variable FSA_DATA_DOT_FOOD_API_HOST is not defined'
+      raise 'Environment variable FSA_DATA_DOT_FOOD_API_URL is not defined'
     end
 
     Rails.application.config.api_host

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,5 +50,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # The API host to use may be available in the environment
-  config.api_host = ENV['FSA_DATA_DOT_FOOD_API_HOST'] || 'http://localhost:8080'
+  config.api_host = ENV['FSA_DATA_DOT_FOOD_API_URL'] || 'http://localhost:8080'
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,4 +48,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # The API host to use may be available in the environment
+  config.api_host = ENV['FSA_DATA_DOT_FOOD_API_HOST'] || 'http://localhost:8080'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,5 +84,5 @@ Rails.application.configure do
   config.relative_url_root = '/catalog'
 
   # The API host to use may be available in the environment
-  config.api_host = ENV['FSA_DATA_DOT_FOOD_API_HOST']
+  config.api_host = ENV['FSA_DATA_DOT_FOOD_API_URL']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,11 +75,14 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
   config.relative_url_root = '/catalog'
+
+  # The API host to use may be available in the environment
+  config.api_host = ENV['FSA_DATA_DOT_FOOD_API_HOST']
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,5 +41,5 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # The API host to use may be available in the environment
-  config.api_host = ENV['FSA_DATA_DOT_FOOD_API_HOST']
+  config.api_host = ENV['FSA_DATA_DOT_FOOD_API_URL']
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # The API host to use may be available in the environment
+  config.api_host = ENV['FSA_DATA_DOT_FOOD_API_HOST']
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,0 @@
-module FsaCatalogBrowser
-  VERSION = '0.1.0'
-end


### PR DESCRIPTION
FoodStandardsAgency/data-dot-food#42
Ensure that the URL of the API endpoint that the catalog browser needs
to get catalog content is defined via an environment variable, to aide
future configuration via a Docker container.

If the environment variable is not set in test or prod environments,
raise an error.