### PR TITLE
Restore live-check functionality

### DIFF
--- a/app/controllers/live_check_controller.rb
+++ b/app/controllers/live_check_controller.rb
@@ -4,7 +4,7 @@ class LiveCheckController < ApplicationController
   before_action :set_cache_headers
 
   def show
-    api = CairnCatalogBrowser::CatalogApi.new
+    api = CatalogApi.new
 
     @view_state = {
       message: 'present',

--- a/app/javascript/src/live_check.js
+++ b/app/javascript/src/live_check.js
@@ -1,2 +1,2 @@
-window.fsaData = window.fsaData || {};
-window.fsaData.liveCheck = 'present';
+window.fsaData = window.fsaData || {}
+window.fsaData.liveCheck = 'present'

--- a/app/views/layouts/live_check.html.erb
+++ b/app/views/layouts/live_check.html.erb
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FSA data catalog live check</title>
 
-    <%= javascript_include_tag 'live_check' %>
+    <%= javascript_pack_tag 'application' %>
   </head>
 
   <body>

--- a/app/views/live_check/show.html.erb
+++ b/app/views/live_check/show.html.erb
@@ -1,6 +1,6 @@
     <main id="main" role="main" tabindex="-1">
       <h1>FSA data catalog: aliveness check</h1>
-      <table id="isAlive" class="table">
+      <table id="isAlive">
         <thead>
           <tr>
             <th>Check</th>
@@ -11,9 +11,6 @@
         <tbody>
           <tr>
             <td>App version</td><td></td><td><%= FsaCatalogBrowser::VERSION %></td>
-          </tr>
-          <tr>
-            <td>Engine version</td><td></td><td><%= CairnCatalogBrowser::VERSION %></td>
           </tr>
           <tr>
             <td>


### PR DESCRIPTION
FoodStandardsAgency/data-dot-food#74
The `live-check` route, which is used by the monitoring scripts to check
that the app is alive stopped working in version 1.0.0 due to a stale
reference to the old Cairn dependency.