### PR TITLE
Tab Order fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # data-dot-food catalog browser change history
 
-## 1.1.4 - 2020-08-07
+## 1.1.5 - 2020-08-07
 
 - Fix for tab order issue, "more years..." link now sets the focus on the years area of the page instead of the results area
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # data-dot-food catalog browser change history
 
+## 1.1.4 - 2020-08-07
+
+- Fix for tab order issue, "more years..." link now sets the focus on the years area of the page instead of the results area
+
 ## 1.1.3 - 2020-07-27
 
 - Fix for GH-81: missing Sentry configuration on Rails application

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -52,6 +52,7 @@ module DatasetsHelper
 
   def all_years_link(prefs)
     dest = search_index_with_param(prefs, :years, 'all', true)
+    dest[:anchor] = 'filter-datasets__heading'
     link_to('more years&hellip;'.html_safe, dest, class: 'c-all-years-link')
   end
 

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 class Version
   MAJOR = 1
   MINOR = 1
-  PATCH = 4
+  PATCH = 5
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 class Version
   MAJOR = 1
   MINOR = 1
-  PATCH = 3
+  PATCH = 4
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end

--- a/test/helpers/datasets_helper_test.rb
+++ b/test/helpers/datasets_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class DatasetsHelperTest < ActionView::TestCase
+  include DatasetsHelper
+
+  let(:prefs) do
+    params = ActionController::Parameters
+             .new
+             .permit(UserPreferences::PERMITTED_PARAMS)
+    UserPreferences.new(params)
+  end
+
+  it 'should return a link with all the years and focus set on datasets heading' do
+    link = all_years_link(prefs)
+    link.must_include '#filter-datasets__heading'
+  end
+end


### PR DESCRIPTION
This PR fixes the issue of tab ordering and focus when clicking on "more years...", as described in this issue: FoodStandardsAgency/data-dot-food#55 . I've set a new anchor for the link that now correctly sets the tab focus on the filter datasets section.

Applying @ijdickinson 's suggestions from the original PR #16 , I will add:
- tests
- bump the version
- changelog entry