### PR TITLE
Fix missing Rubocop config and resolve warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,122 @@
+require: rubocop-rails
+
+AllCops:
+  Exclude:
+    - app/models/regions_table.rb
+    - app/models/locations_table.rb
+    - 'node_modules/**/*'
+
+# Customize rules
+Layout/LineLength:
+  Max: 100
+  Exclude:
+    - bin/**/*
+    - config/**/*
+    - test/**/*
+    - Gemfile
+
+Metrics/ClassLength:
+  Exclude:
+    - test/**/*
+
+Metrics/BlockLength:
+  Exclude:
+    - test/**/*
+    - lib/tasks/**/*
+
+Metrics/MethodLength:
+  Exclude:
+    - lib/tasks/location.rake
+
+Style/FormatStringToken:
+  Enabled: false
+
+Rails/OutputSafety:
+  Exclude:
+    - app/presenters/*.rb
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/MixinUsage:
+  Exclude:
+    - bin/**/*
+
+Metrics/AbcSize:
+  Exclude:
+    - lib/tasks/location.rake
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - lib/tasks/location.rake
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Style/ExponentialNotation:
+  Enabled: true
+Style/RedundantFetchBlock:
+  Enabled: true
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
+Style/SlicingWithRange:
+  Enabled: true
+Lint/DuplicateElsifCondition:
+  Enabled: true
+Style/AccessorGrouping:
+  Enabled: true
+Style/ArrayCoercion:
+  Enabled: true
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/CaseLikeIf:
+  Enabled: true
+Style/HashAsLastArrayItem:
+  Enabled: true
+Style/HashLikeCase:
+  Enabled: true
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+Rails/FindById:
+  Enabled: true
+Rails/Inquiry:
+  Enabled: true
+Rails/MailerName:
+  Enabled: true
+Rails/MatchRoute:
+  Enabled: true
+Rails/NegateInclude:
+  Enabled: true
+Rails/Pluck:
+  Enabled: true
+Rails/PluckInWhere:
+  Enabled: true
+Rails/RenderInline:
+  Enabled: true
+Rails/RenderPlainText:
+  Enabled: true
+Rails/ShortI18n:
+  Enabled: true
+Rails/WhereExists:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # data-dot-food catalog browser change history
 
+## 1.1.5 - 2020-08-07 (Ian)
+
+- added missing .rubocop.yml
+- lots of fixes to resolve Rubocop warnings, most performed automatically
+
 ## 1.1.4 - 2020-07-31 (Ian)
 
 - Fix for GH-82: Sentry error when HTTP Referer field is missing

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 git_source(:github) do |repo_name|
@@ -40,9 +42,7 @@ group :development do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-if RUBY_PLATFORM=~ /win32/
-  gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-end
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby] if RUBY_PLATFORM =~ /win32/
 
 gem 'haml'
 # gem 'fsa_pattern_library', git: 'git@codebasehq.com:epimorphics/fsa-projects/fsa-pattern-library.git'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# :nodoc:
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -32,7 +32,7 @@ class DatasetsController < ApplicationController
   end
 
   def with_compact_view(params)
-    "_view=compact#{params && !params.empty? ? '&' : ''}#{params}"
+    "_view=compact#{params.present? ? '&' : ''}#{params}"
   end
 
   def view_support(params)
@@ -46,7 +46,7 @@ class DatasetsController < ApplicationController
   end
 
   def filter_datasets_by_year(datasets, prefs)
-    if prefs.years && !prefs.years.empty?
+    if prefs.years.present?
       datasets.select do |dataset|
         dataset.years.any? { |year| prefs.years.include?(year) }
       end
@@ -71,10 +71,7 @@ class DatasetsControllerViewSupport
   SUMMARY_YEARS = 5
 
   attr_reader :prefs
-  attr_accessor :datasets
-  attr_accessor :dataset
-  attr_accessor :activity_codes
-  attr_accessor :show_highlighted_datasets
+  attr_accessor :datasets, :dataset, :activity_codes, :show_highlighted_datasets
 
   def initialize(user_preferences)
     @prefs = user_preferences
@@ -111,7 +108,7 @@ class DatasetsControllerViewSupport
   end
 
   def check_year?(year)
-    (prefs.years&.include?(year)) || nil
+    prefs.years&.include?(year) || nil
   end
 
   def filter_defined?
@@ -122,9 +119,9 @@ class DatasetsControllerViewSupport
     @show_highlighted_datasets
   end
 
-  def page_title # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+  def page_title # rubocop:disable Metrics/AbcSize
     titles = []
-    titles.push("search for '#{search}'") if search && !search.empty?
+    titles.push("search for '#{search}'") if search.present?
 
     if !prefs.all_years? && prefs.years
       connective = prefs.years.length > 1 ? 'one of ' : ''

--- a/app/controllers/exception_controller.rb
+++ b/app/controllers/exception_controller.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 # Simple view state container to pass to exception view
 class ExceptionControllerViewState
-  attr_reader :msg
-  attr_reader :status
+  attr_reader :msg, :status
 
   def initialize(msg, status, title = nil)
     @msg = msg
@@ -20,7 +21,7 @@ end
 
 # Controller that also acts a Rack middleware app to
 # handle exceptions
-class ExceptionController < ActionController::Base
+class ExceptionController < ApplicationController
   layout 'application'
 
   def render_error
@@ -34,13 +35,13 @@ class ExceptionController < ActionController::Base
     ex = ActionController::RoutingError.new('')
     @view_state = view_state(ex)
 
-    render 'error_page', status: 404
+    render 'error_page', status: :not_found
   end
 
   private
 
-  def view_state(ex)
-    setup_view(ActionDispatch::ExceptionWrapper.new(request.env, ex))
+  def view_state(exception)
+    setup_view(ActionDispatch::ExceptionWrapper.new(request.env, exception))
   end
 
   def setup_view(wex)
@@ -55,8 +56,8 @@ class ExceptionController < ActionController::Base
     end
   end
 
-  def setup_service_exception_view(ex)
-    svc_exception = ex.exception
+  def setup_service_exception_view(exception)
+    svc_exception = exception.exception
     Rails.logger.debug("ServiceException #{svc_exception.message} \
       #{svc_exception.status} \
       #{svc_exception.service_message} from #{svc_exception.source}")
@@ -64,17 +65,17 @@ class ExceptionController < ActionController::Base
                                      'Something has gone wrong')
   end
 
-  def setup_not_found_exception_view(ex)
-    Rails.logger.debug(ex.exception)
+  def setup_not_found_exception_view(exception)
+    Rails.logger.debug(exception.exception)
     ExceptionControllerViewState.new(
       "Not found: #{ex.exception.message}", 404, 'Page not found'
     )
   end
 
-  def setup_default_exception_view(ex)
-    Rails.logger.debug(ex.exception)
+  def setup_default_exception_view(exception)
+    Rails.logger.debug(exception.exception)
     ExceptionControllerViewState.new(
-      "Sorry, something went wrong: #{ex.exception.message}", 500,
+      "Sorry, something went wrong: #{exception.exception.message}", 500,
       'Something has gone wrong (500)'
     )
   end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class HelpController < ApplicationController
 end

--- a/app/controllers/live_check_controller.rb
+++ b/app/controllers/live_check_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Controller for automated liveness check
 class LiveCheckController < ApplicationController
   layout 'live_check'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,0 @@
-module ApplicationHelper
-end

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -33,7 +33,7 @@ module DatasetsHelper
       elsif from || to
         concat summarise_date_range_abbrev(from || to)
       else
-        concat content_tag(:span, 'Undated', class: 'c-dataset-entry--date-range__default')
+        concat tag.span('Undated', class: 'c-dataset-entry--date-range__default')
       end
     end
   end
@@ -47,7 +47,7 @@ module DatasetsHelper
   end
 
   def summarise_date_range_abbrev(date)
-    content_tag(:time, date.strftime('%b %Y'), datetime: date.strftime('%Y-%m-%d'))
+    tag.time(date.strftime('%b %Y'), datetime: date.strftime('%Y-%m-%d'))
   end
 
   def all_years_link(prefs)
@@ -67,14 +67,14 @@ module DatasetsHelper
 
   def dataset_keyword_filter_add(keyword, prefs, add)
     dataset_filter_add(:keyword, keyword, prefs, add,
-                        maybe_selected_keyword(keyword, add),
-                        'o-dataset-keyword__filter')
+                       maybe_selected_keyword(keyword, add),
+                       'o-dataset-keyword__filter')
   end
 
   def dataset_activity_filter_add(activity, prefs, add)
     dataset_filter_add(:activity, activity.id, prefs, add,
-                        maybe_selected_keyword(activity.full_label, add),
-                        'o-dataset-keyword__filter')
+                       maybe_selected_keyword(activity.full_label, add),
+                       'o-dataset-keyword__filter')
   end
 
   # rubocop:disable Metrics/ParameterLists
@@ -83,7 +83,7 @@ module DatasetsHelper
     if add
       link_to(text, dest, class: cls)
     else
-      content_tag(:span, text, class: cls)
+      tag.span(text, class: cls)
     end
   end
   # rubocop:enable Metrics/ParameterLists
@@ -98,22 +98,23 @@ module DatasetsHelper
 
   def search_index_with_param(prefs, param, param_value, add)
     new_params = if add
-                    prefs.with_param(param.to_sym, param_value)
-                  else
-                    prefs.without_param(param.to_sym)
-                  end
+                   prefs.with_param(param.to_sym, param_value)
+                 else
+                   prefs.without_param(param.to_sym)
+                 end
     { controller: 'datasets', action: 'index', anchor: 'results' }.merge(new_params)
   end
 
   def maybe_selected_keyword(keyword, unselected)
-    cls = unselected ? 'o-dataset-keyword__filter--selectable' : 'o-dataset-keyword__filter--selected'
-    content_tag(:span, keyword, class: cls)
+    cls =
+      unselected ? 'o-dataset-keyword__filter--selectable' : 'o-dataset-keyword__filter--selected'
+    tag.span(keyword, class: cls)
   end
 
   def remove_filter_button(prefs, filter_type, filter_value)
     dest = search_index_with_param(prefs, filter_type, filter_value, false)
     link_to(dest, class: 'c-filter-remove-button') do
-      content_tag(:span, 'Remove filter', class: 'u-sr-only')
+      tag.span('Remove filter', class: 'u-sr-only')
     end
   end
 end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,2 +1,0 @@
-module FeedbackHelper
-end

--- a/app/helpers/help_helper.rb
+++ b/app/helpers/help_helper.rb
@@ -1,2 +1,0 @@
-module HelpHelper
-end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 class Version
   MAJOR = 1
   MINOR = 1
-  PATCH = 4
+  PATCH = 5
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 # Send content of feedback form as email
-class FeedbackMailer < ActionMailer::Base
+class FeedbackMailer < ApplicationMailer
   default from: 'fsa-data-feedback@epimorphics.com'
 
   def feedback_email(questions_and_answers)
     @view_state = questions_and_answers
 
-    now = Time.now.strftime('%H:%M %d-%m-%Y')
+    now = Time.zone.now.strftime('%H:%M %d-%m-%Y')
     mail(to: 'fsa-data-feedback@epimorphics.com',
-         subject: "FSA data catalog feedback - #{now}".html_safe)
+         subject: "FSA data catalog feedback - #{now}")
   end
 end

--- a/app/models/catalog_api_object.rb
+++ b/app/models/catalog_api_object.rb
@@ -2,8 +2,7 @@
 
 # Common implementation for API objects
 class CatalogApiObject
-  attr_reader :json
-  attr_reader :api
+  attr_reader :json, :api
 
   def initialize(json_or_url, api)
     @json = as_json(json_or_url, api).with_indifferent_access
@@ -32,9 +31,7 @@ class CatalogApiObject
     end
   end
 
-  def key?(key)
-    json.key?(key)
-  end
+  delegate :key?, to: :json
 
   private
 
@@ -61,4 +58,4 @@ class CatalogApiObject
       json_or_url
     end
   end
-  end
+end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -89,6 +89,6 @@ class Dataset < CatalogApiObject
   end
 
   def implicit_end_date
-    Date.today if key?(:startDate)
+    Time.zone.today if key?(:startDate)
   end
 end

--- a/app/models/dataset_element.rb
+++ b/app/models/dataset_element.rb
@@ -52,6 +52,6 @@ class DatasetElement < CatalogApiObject
   private
 
   def default_sort_key
-    Date.today
+    Time.zone.today
   end
 end

--- a/app/models/feedback_question.rb
+++ b/app/models/feedback_question.rb
@@ -1,8 +1,8 @@
+# frozen_string_literal: true
+
 # Encapsulates a question we ask on the feedback form
 class FeedbackQuestion
-  attr_reader :id
-  attr_reader :prompt
-  attr_reader :input_type
+  attr_reader :id, :prompt, :input_type
 
   def initialize(question_def)
     @id = question_def['id']

--- a/app/presenters/feedback_questions.rb
+++ b/app/presenters/feedback_questions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Presenter to show feedback questions and answers
 class FeedbackQuestions
   attr_reader :dataset
@@ -7,7 +9,7 @@ class FeedbackQuestions
     @dataset = dataset
 
     question_keys = questions.map(&:id)
-    question_keys << "referer"
+    question_keys << 'referer'
 
     @answers = params.permit(question_keys) if params
   end
@@ -18,7 +20,7 @@ class FeedbackQuestions
 
   def each_qa
     @questions.each do |q|
-      answer = (@answers && @answers[q.id]) || "(no answer given)"
+      answer = (@answers && @answers[q.id]) || '(no answer given)'
       yield(q.id, q.prompt, answer)
     end
   end

--- a/app/services/catalog_api.rb
+++ b/app/services/catalog_api.rb
@@ -63,8 +63,8 @@ class CatalogApi
 
   def api_host
     unless defined?(Rails) &&
-      Rails.application.config.api_host &&
-      !Rails.application.config.api_host.empty?
+           Rails.application.config.api_host &&
+           !Rails.application.config.api_host.empty?
       raise 'Environment variable FSA_DATA_DOT_FOOD_API_URL is not defined'
     end
 

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'fileutils'
 include FileUtils
 

--- a/bin/spring
+++ b/bin/spring
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # This file loads spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
@@ -8,7 +9,7 @@ unless defined?(Spring)
   require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  if spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if (spring = lockfile.specs.detect { |spec| spec.name == 'spring' })
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version
     require 'spring/binstub'

--- a/bin/update
+++ b/bin/update
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'fileutils'
 include FileUtils
 

--- a/bin/webpack
+++ b/bin/webpack
@@ -1,19 +1,20 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV['RAILS_ENV'] ||= ENV['RACK_ENV'] || 'development'
+ENV['NODE_ENV']  ||= 'development'
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile',
+                                           Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-require "webpacker"
-require "webpacker/webpack_runner"
+require 'webpacker'
+require 'webpacker/webpack_runner'
 
-APP_ROOT = File.expand_path("..", __dir__)
+APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   Webpacker::WebpackRunner.run(ARGV)
 end

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -1,19 +1,20 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV['RAILS_ENV'] ||= ENV['RACK_ENV'] || 'development'
+ENV['NODE_ENV']  ||= 'development'
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile',
+                                           Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-require "webpacker"
-require "webpacker/dev_server_runner"
+require 'webpacker'
+require 'webpacker/dev_server_runner'
 
-APP_ROOT = File.expand_path("..", __dir__)
+APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   Webpacker::DevServerRunner.run(ARGV)
 end

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
-  begin
-    exec "yarnpkg", *ARGV
-  rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec 'yarnpkg', *ARGV
+rescue Errno::ENOENT
+  warn 'Yarn executable was not detected in the system.'
+  warn 'Download Yarn at https://yarnpkg.com/en/docs/install'
+  exit 1
 end

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 require 'rails'
@@ -17,6 +19,7 @@ require 'rails/test_unit/railtie'
 Bundler.require(*Rails.groups)
 
 module DataCatalogBrowser
+  # :nodoc:
   class Application < Rails::Application
     # Settings in config/environments/* take precedence
     # Application configuration should go into files in config/initializers

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative 'application'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -47,7 +49,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/initializers/additional_autoload_paths.rb
+++ b/config/initializers/additional_autoload_paths.rb
@@ -1,1 +1,6 @@
-Rails.application.config.autoload_paths += ["#{Rails.root}/app/services", "#{Rails.root}/app/presenters"]
+# frozen_string_literal: true
+
+Rails.application.config.autoload_paths += [
+  Rails.root.join('/app/services'),
+  Rails.root.join('/app/presenters')
+]

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # ApplicationController.renderer.defaults.merge!(

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
@@ -10,4 +12,4 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
 
-Rails.application.config.assets.precompile += %w(live_check.js)
+Rails.application.config.assets.precompile += %w[live_check.js]

--- a/config/initializers/aws_email.rb
+++ b/config/initializers/aws_email.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # Use AWS to send email
 Rails.application.config.action_mailer.delivery_method = :ses

--- a/config/initializers/aws_region.rb
+++ b/config/initializers/aws_region.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # Set the default AWS region
 Aws.config.update(region: 'eu-west-1')

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_data-catalog-browser_session', domain: 'fsa-staging-dfgu.epimorphics.net'

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
+threads_count = ENV.fetch('RAILS_MAX_THREADS', 5).to_i
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch('PORT', 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV', 'development')
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,8 @@
-%w(
+# frozen_string_literal: true
+
+%w[
   .ruby-version
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-).each { |path| Spring.watch(path) }
+].each { |path| Spring.watch(path) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,0 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)

--- a/test/controllers/help_controller_test.rb
+++ b/test/controllers/help_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class HelpControllerTest < ActionDispatch::IntegrationTest

--- a/test/models/dataset_element_test.rb
+++ b/test/models/dataset_element_test.rb
@@ -9,7 +9,7 @@ class DatasetElementTest < ActiveSupport::TestCase
   let :element_fixture do
     VCR.use_cassette('load_dataset_element') do
       api = CatalogApi.new
-      api.dataset_element('c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d') # rubocop:disable Metrics/LineLength
+      api.dataset_element('c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d')
     end
   end
 
@@ -75,6 +75,6 @@ class DatasetElementTest < ActiveSupport::TestCase
 
     k = DatasetElement.new({}, nil).sort_key
     k.must_be_kind_of Date
-    k.year.must_equal Time.now.year
+    k.year.must_equal Time.zone.now.year
   end
 end

--- a/test/models/dataset_test.rb
+++ b/test/models/dataset_test.rb
@@ -91,7 +91,7 @@ class DatasetTest < ActiveSupport::TestCase
   it 'will return the time range of the dataset elements' do
     dataset_fixture.date_range[:from].must_be_kind_of Date
     dataset_fixture.date_range[:to].must_be_kind_of Date
-    dataset_fixture.date_range[:from].must_be :<=, dataset_fixture.date_range[:to] # rubocop:disable Metrics/LineLength
+    dataset_fixture.date_range[:from].must_be :<=, dataset_fixture.date_range[:to]
   end
 
   it 'will report the years covered by the attached elements' do
@@ -99,7 +99,7 @@ class DatasetTest < ActiveSupport::TestCase
     dataset_fixture.years.length.must_be :>=, 4
   end
 
-  it 'will return an array of all of the activities under which the ds is defined' do # rubocop:disable Metrics/LineLength
+  it 'will return an array of all of the activities under which the ds is defined' do
     VCR.use_cassette('load_activity_codes') do
       dataset_fixture.activities.length.must_equal 1
       dataset_fixture.activities.first.must_be_kind_of ActivityCode

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,7 +51,7 @@ module MiniTest
     end
 
     def assert_not_truthy(proposition)
-      assert !proposition
+      assert_not proposition
     end
   end
 end

--- a/test/vcr_cassettes/dataset_distribution.yml
+++ b/test/vcr_cassettes/dataset_distribution.yml
@@ -2,54 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: http://18.202.57.165:8080/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.15.4
-      Accept:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      vary:
-      - Accept
-      x-response-id:
-      - '146'
-      cache-control:
-      - no-transform, max-age=0
-      content-type:
-      - application/json
-      content-length:
-      - '1106'
-      date:
-      - Tue, 12 May 2020 16:45:14 GMT
-      connection:
-      - close
-      server:
-      - Server
-    body:
-      encoding: UTF-8
-      string: "{ \n  \"@context\" : \"http://data.food.gov.uk/catalog/meta/context.jsonld\"
-        ,\n  \"meta\" : { \n    \"publisher\" : \"Food Standards Agency\" ,\n    \"licence\"
-        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
-        ,\n    \"documentation\" : \"http://data.food.gov.uk/catalog/doc\" ,\n    \"version\"
-        : \"0.0\" ,\n    \"comment\" : \"Status: Alpha service\" ,\n    \"hasFormat\"
-        : [ \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956.rdf\",
-        \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956.ttl\",
-        \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956.html\"
-        ]\n  }\n   ,\n  \"items\" : [ { \n    \"@id\" : \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956\"
-        ,\n    \"downloadURL\" : \"https://fsadata.github.io/data-sharing-register/data/data-sharing-register-for-2016.csv\"
-        ,\n    \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956\"
-        ,\n    \"mediaType\" : \"text/csv\" ,\n    \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \ }\n   ]\n}\n\n"
-  recorded_at: Tue, 12 May 2020 16:45:15 GMT
-- request:
-    method: get
     uri: http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956
     body:
       encoding: US-ASCII
@@ -133,4 +85,52 @@ http_interactions:
         ,\n    \"mediaType\" : \"text/csv\" ,\n    \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
         \ }\n   ]\n}\n\n"
   recorded_at: Fri, 31 Jul 2020 07:54:46 GMT
+- request:
+    method: get
+    uri: http://18.202.57.165:8080/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      vary:
+      - Accept
+      x-response-id:
+      - '35'
+      cache-control:
+      - no-transform, max-age=0
+      content-type:
+      - application/json
+      content-length:
+      - '1106'
+      date:
+      - Fri, 07 Aug 2020 12:44:55 GMT
+      connection:
+      - close
+      server:
+      - Server
+    body:
+      encoding: UTF-8
+      string: "{ \n  \"@context\" : \"http://data.food.gov.uk/catalog/meta/context.jsonld\"
+        ,\n  \"meta\" : { \n    \"publisher\" : \"Food Standards Agency\" ,\n    \"licence\"
+        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
+        ,\n    \"documentation\" : \"http://data.food.gov.uk/catalog/doc\" ,\n    \"version\"
+        : \"0.0\" ,\n    \"comment\" : \"Status: Alpha service\" ,\n    \"hasFormat\"
+        : [ \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956.rdf\",
+        \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956.ttl\",
+        \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956.html\"
+        ]\n  }\n   ,\n  \"items\" : [ { \n    \"@id\" : \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956\"
+        ,\n    \"downloadURL\" : \"https://fsadata.github.io/data-sharing-register/data/data-sharing-register-for-2016.csv\"
+        ,\n    \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956\"
+        ,\n    \"mediaType\" : \"text/csv\" ,\n    \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \ }\n   ]\n}\n\n"
+  recorded_at: Fri, 07 Aug 2020 12:44:55 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/load_activity_codes.yml
+++ b/test/vcr_cassettes/load_activity_codes.yml
@@ -2,95 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: http://18.202.57.165:8080/catalog/data/activities
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.15.4
-      Accept:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      vary:
-      - Accept
-      x-response-id:
-      - '145'
-      cache-control:
-      - no-transform, max-age=0
-      content-type:
-      - application/json
-      content-length:
-      - '4186'
-      date:
-      - Tue, 12 May 2020 16:45:14 GMT
-      connection:
-      - close
-      server:
-      - Server
-    body:
-      encoding: UTF-8
-      string: "{ \n  \"@context\" : \"http://data.food.gov.uk/catalog/meta/context.jsonld\"
-        ,\n  \"meta\" : { \n    \"publisher\" : \"Food Standards Agency\" ,\n    \"licence\"
-        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
-        ,\n    \"documentation\" : \"http://data.food.gov.uk/catalog/doc\" ,\n    \"version\"
-        : \"0.0\" ,\n    \"comment\" : \"Status: Alpha service\" ,\n    \"hasFormat\"
-        : [ \"http://data.food.gov.uk/catalog/data/activities.csv\", \"http://data.food.gov.uk/catalog/data/activities.rdf\",
-        \"http://data.food.gov.uk/catalog/data/activities.ttl\", \"http://data.food.gov.uk/catalog/data/activities.html\"
-        ]\n  }\n   ,\n  \"items\" : [ { \n    \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/6\"
-        ,\n    \"inScheme\" : \"http://data.food.gov.uk/codes/organisation/activities\"
-        ,\n    \"label\" : \"Running the Organisation\" ,\n    \"narrower\" : [ {
-        \n      \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/6-1\"
-        ,\n      \"label\" : \"Financial\" ,\n      \"notation\" : \"6-1\"\n    }\n
-        \   , { \n      \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/6-2\"
-        ,\n      \"label\" : \"HR\" ,\n      \"notation\" : \"6-2\"\n    }\n    ,
-        { \n      \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/6-3\"
-        ,\n      \"label\" : \"Other\" ,\n      \"notation\" : \"6-3\"\n    }\n     ]
-        ,\n    \"notation\" : 6 ,\n    \"prefLabel\" : \"Running the Organisation\"
-        ,\n    \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
-        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n  }\n  , { \n    \"@id\"
-        : \"http://data.food.gov.uk/codes/organisation/activities/5\" ,\n    \"inScheme\"
-        : \"http://data.food.gov.uk/codes/organisation/activities\" ,\n    \"label\"
-        : \"Enforcement\" ,\n    \"notation\" : 5 ,\n    \"prefLabel\" : \"Enforcement\"
-        ,\n    \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
-        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n  }\n  , { \n    \"@id\"
-        : \"http://data.food.gov.uk/codes/organisation/activities/4\" ,\n    \"inScheme\"
-        : \"http://data.food.gov.uk/codes/organisation/activities\" ,\n    \"label\"
-        : \"Safety\" ,\n    \"notation\" : 4 ,\n    \"prefLabel\" : \"Safety\" ,\n
-        \   \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\", \"http://www.w3.org/2004/02/skos/core#Concept\"
-        ]\n  }\n  , { \n    \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1\"
-        ,\n    \"inScheme\" : \"http://data.food.gov.uk/codes/organisation/activities\"
-        ,\n    \"label\" : \"Regulation\" ,\n    \"narrower\" : [ { \n      \"@id\"
-        : \"http://data.food.gov.uk/codes/organisation/activities/1-1\" ,\n      \"label\"
-        : \"Legislation\" ,\n      \"narrower\" : [ { \n        \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1-1-1\"
-        ,\n        \"label\" : \"UK\" ,\n        \"notation\" : \"1-1-1\"\n      }\n
-        \     , { \n        \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1-1-2\"
-        ,\n        \"label\" : \"EU\" ,\n        \"notation\" : \"1-1-2\"\n      }\n
-        \     , { \n        \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1-1-3\"
-        ,\n        \"label\" : \"WHO\" ,\n        \"notation\" : \"1-1-3\"\n      }\n
-        \     , { \n        \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1-1-4\"
-        ,\n        \"label\" : \"Other\" ,\n        \"notation\" : \"1-1-4\"\n      }\n
-        \      ] ,\n      \"notation\" : \"1-1\"\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/codes/organisation/activities/1-2\" ,\n      \"label\"
-        : \"Non-Legislation\" ,\n      \"notation\" : \"1-2\"\n    }\n     ] ,\n    \"notation\"
-        : 1 ,\n    \"prefLabel\" : \"Regulation\" ,\n    \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
-        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n  }\n  , { \n    \"@id\"
-        : \"http://data.food.gov.uk/codes/organisation/activities/3\" ,\n    \"inScheme\"
-        : \"http://data.food.gov.uk/codes/organisation/activities\" ,\n    \"label\"
-        : \"Policy\" ,\n    \"notation\" : 3 ,\n    \"prefLabel\" : \"Policy\" ,\n
-        \   \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\", \"http://www.w3.org/2004/02/skos/core#Concept\"
-        ]\n  }\n  , { \n    \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/2\"
-        ,\n    \"inScheme\" : \"http://data.food.gov.uk/codes/organisation/activities\"
-        ,\n    \"label\" : \"Research\" ,\n    \"notation\" : 2 ,\n    \"prefLabel\"
-        : \"Research\" ,\n    \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
-        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n  }\n   ]\n}\n\n"
-  recorded_at: Tue, 12 May 2020 16:45:14 GMT
-- request:
-    method: get
     uri: http://data.food.gov.uk/catalog/data/activities
     body:
       encoding: US-ASCII
@@ -215,4 +126,93 @@ http_interactions:
         : \"Research\" ,\n    \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
         \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n  }\n   ]\n}\n\n"
   recorded_at: Fri, 31 Jul 2020 07:54:53 GMT
+- request:
+    method: get
+    uri: http://18.202.57.165:8080/catalog/data/activities
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      vary:
+      - Accept
+      x-response-id:
+      - '41'
+      cache-control:
+      - no-transform, max-age=0
+      content-type:
+      - application/json
+      content-length:
+      - '4186'
+      date:
+      - Fri, 07 Aug 2020 12:44:56 GMT
+      connection:
+      - close
+      server:
+      - Server
+    body:
+      encoding: UTF-8
+      string: "{ \n  \"@context\" : \"http://data.food.gov.uk/catalog/meta/context.jsonld\"
+        ,\n  \"meta\" : { \n    \"publisher\" : \"Food Standards Agency\" ,\n    \"licence\"
+        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
+        ,\n    \"documentation\" : \"http://data.food.gov.uk/catalog/doc\" ,\n    \"version\"
+        : \"0.0\" ,\n    \"comment\" : \"Status: Alpha service\" ,\n    \"hasFormat\"
+        : [ \"http://data.food.gov.uk/catalog/data/activities.csv\", \"http://data.food.gov.uk/catalog/data/activities.rdf\",
+        \"http://data.food.gov.uk/catalog/data/activities.ttl\", \"http://data.food.gov.uk/catalog/data/activities.html\"
+        ]\n  }\n   ,\n  \"items\" : [ { \n    \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/6\"
+        ,\n    \"inScheme\" : \"http://data.food.gov.uk/codes/organisation/activities\"
+        ,\n    \"label\" : \"Running the Organisation\" ,\n    \"narrower\" : [ {
+        \n      \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/6-1\"
+        ,\n      \"label\" : \"Financial\" ,\n      \"notation\" : \"6-1\"\n    }\n
+        \   , { \n      \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/6-2\"
+        ,\n      \"label\" : \"HR\" ,\n      \"notation\" : \"6-2\"\n    }\n    ,
+        { \n      \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/6-3\"
+        ,\n      \"label\" : \"Other\" ,\n      \"notation\" : \"6-3\"\n    }\n     ]
+        ,\n    \"notation\" : 6 ,\n    \"prefLabel\" : \"Running the Organisation\"
+        ,\n    \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
+        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n  }\n  , { \n    \"@id\"
+        : \"http://data.food.gov.uk/codes/organisation/activities/5\" ,\n    \"inScheme\"
+        : \"http://data.food.gov.uk/codes/organisation/activities\" ,\n    \"label\"
+        : \"Enforcement\" ,\n    \"notation\" : 5 ,\n    \"prefLabel\" : \"Enforcement\"
+        ,\n    \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
+        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n  }\n  , { \n    \"@id\"
+        : \"http://data.food.gov.uk/codes/organisation/activities/4\" ,\n    \"inScheme\"
+        : \"http://data.food.gov.uk/codes/organisation/activities\" ,\n    \"label\"
+        : \"Safety\" ,\n    \"notation\" : 4 ,\n    \"prefLabel\" : \"Safety\" ,\n
+        \   \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\", \"http://www.w3.org/2004/02/skos/core#Concept\"
+        ]\n  }\n  , { \n    \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1\"
+        ,\n    \"inScheme\" : \"http://data.food.gov.uk/codes/organisation/activities\"
+        ,\n    \"label\" : \"Regulation\" ,\n    \"narrower\" : [ { \n      \"@id\"
+        : \"http://data.food.gov.uk/codes/organisation/activities/1-1\" ,\n      \"label\"
+        : \"Legislation\" ,\n      \"narrower\" : [ { \n        \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1-1-1\"
+        ,\n        \"label\" : \"UK\" ,\n        \"notation\" : \"1-1-1\"\n      }\n
+        \     , { \n        \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1-1-2\"
+        ,\n        \"label\" : \"EU\" ,\n        \"notation\" : \"1-1-2\"\n      }\n
+        \     , { \n        \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1-1-3\"
+        ,\n        \"label\" : \"WHO\" ,\n        \"notation\" : \"1-1-3\"\n      }\n
+        \     , { \n        \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/1-1-4\"
+        ,\n        \"label\" : \"Other\" ,\n        \"notation\" : \"1-1-4\"\n      }\n
+        \      ] ,\n      \"notation\" : \"1-1\"\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/codes/organisation/activities/1-2\" ,\n      \"label\"
+        : \"Non-Legislation\" ,\n      \"notation\" : \"1-2\"\n    }\n     ] ,\n    \"notation\"
+        : 1 ,\n    \"prefLabel\" : \"Regulation\" ,\n    \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
+        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n  }\n  , { \n    \"@id\"
+        : \"http://data.food.gov.uk/codes/organisation/activities/3\" ,\n    \"inScheme\"
+        : \"http://data.food.gov.uk/codes/organisation/activities\" ,\n    \"label\"
+        : \"Policy\" ,\n    \"notation\" : 3 ,\n    \"prefLabel\" : \"Policy\" ,\n
+        \   \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\", \"http://www.w3.org/2004/02/skos/core#Concept\"
+        ]\n  }\n  , { \n    \"@id\" : \"http://data.food.gov.uk/codes/organisation/activities/2\"
+        ,\n    \"inScheme\" : \"http://data.food.gov.uk/codes/organisation/activities\"
+        ,\n    \"label\" : \"Research\" ,\n    \"notation\" : 2 ,\n    \"prefLabel\"
+        : \"Research\" ,\n    \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
+        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n  }\n   ]\n}\n\n"
+  recorded_at: Fri, 07 Aug 2020 12:44:56 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/load_dataset.yml
+++ b/test/vcr_cassettes/load_dataset.yml
@@ -2,344 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: http://18.202.57.165:8080/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.15.4
-      Accept:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      vary:
-      - Accept
-      x-response-id:
-      - '144'
-      cache-control:
-      - no-transform, max-age=0
-      content-type:
-      - application/json
-      transfer-encoding:
-      - chunked
-      date:
-      - Tue, 12 May 2020 16:45:14 GMT
-      connection:
-      - close
-      server:
-      - Server
-    body:
-      encoding: UTF-8
-      string: "{ \n  \"@context\" : \"http://data.food.gov.uk/catalog/meta/context.jsonld\"
-        ,\n  \"meta\" : { \n    \"publisher\" : \"Food Standards Agency\" ,\n    \"licence\"
-        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
-        ,\n    \"documentation\" : \"http://data.food.gov.uk/catalog/doc\" ,\n    \"version\"
-        : \"0.0\" ,\n    \"comment\" : \"Status: Alpha service\" ,\n    \"hasFormat\"
-        : [ \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90.rdf\",
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90.ttl\",
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90.html\"
-        ]\n  }\n   ,\n  \"items\" : [ { \n    \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n    \"accrualPeriodicity\" : \"R/P3M\" ,\n    \"activity\" : [ { \n      \"@id\"
-        : \"http://data.food.gov.uk/codes/organisation/activities/6-2\" ,\n      \"broader\"
-        : \"http://data.food.gov.uk/codes/organisation/activities/6\" ,\n      \"inScheme\"
-        : \"http://data.food.gov.uk/codes/organisation/activities\" ,\n      \"label\"
-        : \"HR\" ,\n      \"notation\" : \"6-2\" ,\n      \"prefLabel\" : \"HR\" ,\n
-        \     \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
-        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n    }\n     ] ,\n    \"description\"
-        : \"A quarterly-update of the gifts and hospitality received and registered
-        by FSA Board members and Directors\" ,\n    \"directorate\" : { \n      \"@id\"
-        : \"http://data.food.gov.uk/codes/organisation/directorates/D01\" ,\n      \"inScheme\"
-        : \"http://data.food.gov.uk/codes/organisation/directorates\" ,\n      \"label\"
-        : \"Chief Executive & Directors\" ,\n      \"notation\" : \"D01\" ,\n      \"prefLabel\"
-        : \"Chief Executive & Directors\" ,\n      \"topConceptOf\" : \"http://data.food.gov.uk/codes/organisation/directorates\"
-        ,\n      \"type\" : \"http://data.food.gov.uk/def/organisation/Directorate\"\n
-        \   }\n     ,\n    \"elements\" : [ { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/02471d9be8eeb726f4840bf4c6fd4428\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2015-16 Quarter 1\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/ed2b5757-04a7-4431-ada3-ee18da130dc6\"
-        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/gifts-hospitality-2015-16-q1.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/ed2b5757-04a7-4431-ada3-ee18da130dc6\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2015-06-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/02471d9be8eeb726f4840bf4c6fd4428\"
-        ,\n      \"startDate\" : \"2015-04-01\" ,\n      \"temporal\" : \"2015-04-01/2015-06-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2015-16 Quarter 1\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/0c9eb8413007f14c69e3a4d3dd19785e\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2013-14 Quarter 4\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/2e8533c0-edcc-49b4-b830-506fe15e9ad0\"
-        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2013-14q4.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/2e8533c0-edcc-49b4-b830-506fe15e9ad0\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2014-03-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/0c9eb8413007f14c69e3a4d3dd19785e\"
-        ,\n      \"startDate\" : \"2014-01-01\" ,\n      \"temporal\" : \"2014-01-01/2014-03-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2013-14 Quarter 4\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
-        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/11fc247cf0765f9222911fa83be3bdda\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2014-15 Quarter 3\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/3b4000b0-6052-41fd-8d23-69d727f56752\"
-        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2014-15-q3.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/3b4000b0-6052-41fd-8d23-69d727f56752\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2014-12-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/11fc247cf0765f9222911fa83be3bdda\"
-        ,\n      \"startDate\" : \"2014-10-01\" ,\n      \"temporal\" : \"2014-10-01/2014-12-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2014-15 Quarter 3\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/21fece772e388f812bd913462870bdf8\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2013-14 Quarter 3\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/69f81e4b-47e3-4c5e-a4ac-3404341874ca\"
-        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2013-14q3.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/69f81e4b-47e3-4c5e-a4ac-3404341874ca\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2013-12-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/21fece772e388f812bd913462870bdf8\"
-        ,\n      \"startDate\" : \"2013-10-01\" ,\n      \"temporal\" : \"2013-10-01/2013-12-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2013-14 Quarter 3\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
-        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2c5b77a1-33c9-49a4-a3af-f4ac83bd6bbc\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2015-16 Quarter 3 (October 2015 - December 2015).\" ,\n      \"distribution\"
-        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/ea094b02-23c3-4806-88c7-428c481e6b62\"
-        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2015-16-quarter-3.csv\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2015-12-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2c5b77a1-33c9-49a4-a3af-f4ac83bd6bbc\"
-        ,\n      \"startDate\" : \"2015-10-01\" ,\n      \"temporal\" : \"2015-10-01/2015-12-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2015-16 Quarter 3\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2c698a6b39dae342917d70ea8e2c7755\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2014-15 Quarter 2\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/e840f89f-f346-4cb8-ab57-91b6001d559a\"
-        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-hosp-gifts-2014-15-q2.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/e840f89f-f346-4cb8-ab57-91b6001d559a\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2014-09-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2c698a6b39dae342917d70ea8e2c7755\"
-        ,\n      \"startDate\" : \"2014-07-01\" ,\n      \"temporal\" : \"2014-07-01/2014-09-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2014-15 Quarter 2\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2e69be1dcf9521c7c2fec4568b5f9f70\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2014-15 Quarter 4\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/c52cb7d4-7f29-4dd7-a712-fecf0c879c40\"
-        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2014-15-q4.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/c52cb7d4-7f29-4dd7-a712-fecf0c879c40\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2015-03-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2e69be1dcf9521c7c2fec4568b5f9f70\"
-        ,\n      \"startDate\" : \"2015-01-01\" ,\n      \"temporal\" : \"2015-01-01/2015-03-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2014-15 Quarter 4\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/39b19008-adb3-4f7f-9104-d20a2a22c424\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2015-16 Quarter 4 (January 2016 - March 2016).\" ,\n      \"distribution\"
-        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/2d19ce74-c400-4d47-a9c7-e9f44cb253f4\"
-        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2015-16-quarter-4.csv\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2016-03-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/39b19008-adb3-4f7f-9104-d20a2a22c424\"
-        ,\n      \"startDate\" : \"2016-01-01\" ,\n      \"temporal\" : \"2016-01-01/2016-03-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2015-16 Quarter 4\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/3b9644b9-b0b1-43e8-88e0-7e5207990f11\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2016-17 Quarter 3 (October 2016 - December 2016).\" ,\n      \"distribution\"
-        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/7f567e23-d38c-4edd-a74e-8a28628ea006\"
-        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2016-17-quarter-3.csv\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2016-12-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/3b9644b9-b0b1-43e8-88e0-7e5207990f11\"
-        ,\n      \"startDate\" : \"2016-10-01\" ,\n      \"temporal\" : \"2016-10-01/2016-12-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2016-17 Quarter 3\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/64c45558ea8ab5ab6efd8eac05cf1a28\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2013-14 Quarter 1\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/4658dd7c-31a7-4f0c-a068-fc2a36704199\"
-        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2013-14q1.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/4658dd7c-31a7-4f0c-a068-fc2a36704199\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2013-06-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/64c45558ea8ab5ab6efd8eac05cf1a28\"
-        ,\n      \"startDate\" : \"2013-04-01\" ,\n      \"temporal\" : \"2013-04-01/2013-06-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2013-14 Quarter 1\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
-        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/706f75f3caf5d3f491ae1e14d37ab201\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2013-14 Quarter 2\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/43e73335-2650-4d8b-86a8-3354f3ac6ab1\"
-        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2013-14q2.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/43e73335-2650-4d8b-86a8-3354f3ac6ab1\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2013-09-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/706f75f3caf5d3f491ae1e14d37ab201\"
-        ,\n      \"startDate\" : \"2013-07-01\" ,\n      \"temporal\" : \"2013-07-01/2013-09-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2013-14 Quarter 2\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
-        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/752fe35f-6210-4b41-a9bf-d06188f56407\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2016-17 Quarter 1 (April 2017 - June 2017).\" ,\n      \"distribution\"
-        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/ce4eae53-dc2c-482b-89c7-c326bf830572\"
-        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2017-18-quarter-1.csv\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2017-06-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/752fe35f-6210-4b41-a9bf-d06188f56407\"
-        ,\n      \"startDate\" : \"2017-04-01\" ,\n      \"temporal\" : \"2017-04-01/2017-06-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2017-18 Quarter 1\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/9dd6d5a5-fa65-458d-939d-33c1dcb6172b\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2016-17 Quarter 2 (July 2016 - September 2016).\" ,\n      \"distribution\"
-        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/6e824fba-bf4b-4521-9efd-3a3b656ab9fa\"
-        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2016-17-quarter-2.csv\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2016-09-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/9dd6d5a5-fa65-458d-939d-33c1dcb6172b\"
-        ,\n      \"startDate\" : \"2016-07-01\" ,\n      \"temporal\" : \"2016-07-01/2016-09-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2016-17 Quarter 2\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/a85b71932cfb4b0241b7591baf667d64\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2014-15 Quarter 1\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/afdb8085-36f4-4060-ba77-b0dd269c216e\"
-        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2014-15q1.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/afdb8085-36f4-4060-ba77-b0dd269c216e\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2014-06-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/a85b71932cfb4b0241b7591baf667d64\"
-        ,\n      \"startDate\" : \"2014-04-01\" ,\n      \"temporal\" : \"2014-04-01/2014-06-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2014-15 Quarter 1\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/c6273910a48b316516ba8336cd832959\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2015-16 Quarter 2\" ,\n      \"distribution\" : { \n        \"@id\"
-        : \"http://data.food.gov.uk/catalog/data/distribution/d0e1ac12-2fbe-4e52-8f6b-ce55b9fad6be\"
-        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/gifts-hospitality-2015-16-q2.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/d0e1ac12-2fbe-4e52-8f6b-ce55b9fad6be\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2015-09-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/c6273910a48b316516ba8336cd832959\"
-        ,\n      \"startDate\" : \"2015-07-01\" ,\n      \"temporal\" : \"2015-07-01/2015-09-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2015-16 Quarter 2\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/c90ea6bc-b4b4-4512-9337-7d0de5399b10\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2017-18 Quarter 3 (October 2017 - December 2017).\" ,\n      \"distribution\"
-        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/7fd86d10-80e5-44ce-942c-1a2fb1629a46\"
-        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2017-18-quarter-3.csv\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2017-12-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/c90ea6bc-b4b4-4512-9337-7d0de5399b10\"
-        ,\n      \"startDate\" : \"2017-10-01\" ,\n      \"temporal\" : \"2017-10-01/2017-12-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2017-18 Quarter 3\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/cc2c97f6-2d8f-4ec2-ba74-6d336418e7dd\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2017-18 Quarter 2 (July 2017 - September 2017).\" ,\n      \"distribution\"
-        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/d73bcf57-5034-4ccb-aa7d-fc11ef179e28\"
-        ,\n        \"accessURL\" : \"\" ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2017-18-quarter-2.csv\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2017-09-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/cc2c97f6-2d8f-4ec2-ba74-6d336418e7dd\"
-        ,\n      \"startDate\" : \"2017-07-01\" ,\n      \"temporal\" : \"2017-07-01/2017-09-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2017-18 Quarter 2\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/e7766f133c86d9121db46ed9e8d6ee4f\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2012-2013\" ,\n      \"distribution\" : { \n        \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/distribution/b26cab95-0ca5-4a04-8d7d-a5db2b676d36\"
-        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2012-13.csv\"
-        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/b26cab95-0ca5-4a04-8d7d-a5db2b676d36\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2013-03-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/e7766f133c86d9121db46ed9e8d6ee4f\"
-        ,\n      \"startDate\" : \"2012-04-01\" ,\n      \"temporal\" : \"2012-04-01/2013-03-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2012-2013\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
-        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/faa91a1f-de74-45eb-be9e-226a30154052\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2016-17 Quarter 1 (April 2016 - June 2016).\" ,\n      \"distribution\"
-        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/c990128f-ef7f-4a8f-8be1-40ad97807911\"
-        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2016-17-quarter-1.csv\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2016-06-30\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/faa91a1f-de74-45eb-be9e-226a30154052\"
-        ,\n      \"startDate\" : \"2016-04-01\" ,\n      \"temporal\" : \"2016-04-01/2016-06-30\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2016-17 Quarter 1\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
-        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/fe00a63b-867e-4fb3-98f1-95d35b2fd2eb\"
-        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n      \"description\" : \"FSA Board and directors registered gifts and
-        hospitality 2016-17 Quarter 4 (January 2017 - March 2017).\" ,\n      \"distribution\"
-        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/8df87316-0766-492d-a6e3-c776d5d43e3f\"
-        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2016-17-quarter-4.csv\"
-        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \     }\n       ,\n      \"endDate\" : \"2017-03-31\" ,\n      \"identifier\"
-        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/fe00a63b-867e-4fb3-98f1-95d35b2fd2eb\"
-        ,\n      \"startDate\" : \"2017-01-01\" ,\n      \"temporal\" : \"2017-01-01/2017-03-31\"
-        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
-        2016-17 Quarter 4\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
-        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n     ] ,\n    \"endDate\"
-        : \"2017-12-31\" ,\n    \"identifier\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
-        ,\n    \"issued\" : \"2014-04-01\" ,\n    \"keyword\" : [ \"gifts\", \"transparency\"
-        ] ,\n    \"keywords\" : [ \"http://data.food.gov.uk/catalog/data/keyword/gifts\",
-        \"http://data.food.gov.uk/catalog/data/keyword/transparency\" ] ,\n    \"landingPage\"
-        : \"https://data.gov.uk/dataset/fsa-board-and-directors-registered-gifts-and-hospitality\"
-        ,\n    \"license\" : { \n      \"@id\" : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
-        ,\n      \"label\" : \"Open Government Licence (v3)\" ,\n      \"notation\"
-        : \"OGLv3\" ,\n      \"prefLabel\" : \"Open Government Licence (v3)\" ,\n
-        \     \"type\" : [ \"http://creativecommons.org/ns#License\", \"http://schema.theodi.org/odrs#License\"
-        ]\n    }\n     ,\n    \"modified\" : \"2018-05-11\" ,\n    \"published\" :
-        true ,\n    \"publisher\" : \"http://www.food.gov.uk/#id\" ,\n    \"startDate\"
-        : \"2012-04-01\" ,\n    \"temporal\" : \"2012-04-01/2017-12-31\" ,\n    \"title\"
-        : \"Register of Gifts and Hospitality\" ,\n    \"type\" : \"http://vocab.epimorphics.com/def/catalog/Dataset\"\n
-        \ }\n   ]\n}\n\n"
-  recorded_at: Tue, 12 May 2020 16:45:14 GMT
-- request:
-    method: get
     uri: http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90
     body:
       encoding: US-ASCII
@@ -765,4 +427,342 @@ http_interactions:
         : \"Register of Gifts and Hospitality\" ,\n    \"type\" : \"http://vocab.epimorphics.com/def/catalog/Dataset\"\n
         \ }\n   ]\n}\n\n"
   recorded_at: Fri, 31 Jul 2020 07:54:51 GMT
+- request:
+    method: get
+    uri: http://18.202.57.165:8080/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      vary:
+      - Accept
+      x-response-id:
+      - '56'
+      cache-control:
+      - no-transform, max-age=0
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      date:
+      - Fri, 07 Aug 2020 12:44:58 GMT
+      connection:
+      - close
+      server:
+      - Server
+    body:
+      encoding: UTF-8
+      string: "{ \n  \"@context\" : \"http://data.food.gov.uk/catalog/meta/context.jsonld\"
+        ,\n  \"meta\" : { \n    \"publisher\" : \"Food Standards Agency\" ,\n    \"licence\"
+        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
+        ,\n    \"documentation\" : \"http://data.food.gov.uk/catalog/doc\" ,\n    \"version\"
+        : \"0.0\" ,\n    \"comment\" : \"Status: Alpha service\" ,\n    \"hasFormat\"
+        : [ \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90.rdf\",
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90.ttl\",
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90.html\"
+        ]\n  }\n   ,\n  \"items\" : [ { \n    \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n    \"accrualPeriodicity\" : \"R/P3M\" ,\n    \"activity\" : [ { \n      \"@id\"
+        : \"http://data.food.gov.uk/codes/organisation/activities/6-2\" ,\n      \"broader\"
+        : \"http://data.food.gov.uk/codes/organisation/activities/6\" ,\n      \"inScheme\"
+        : \"http://data.food.gov.uk/codes/organisation/activities\" ,\n      \"label\"
+        : \"HR\" ,\n      \"notation\" : \"6-2\" ,\n      \"prefLabel\" : \"HR\" ,\n
+        \     \"type\" : [ \"http://data.food.gov.uk/def/organisation/Activity\",
+        \"http://www.w3.org/2004/02/skos/core#Concept\" ]\n    }\n     ] ,\n    \"description\"
+        : \"A quarterly-update of the gifts and hospitality received and registered
+        by FSA Board members and Directors\" ,\n    \"directorate\" : { \n      \"@id\"
+        : \"http://data.food.gov.uk/codes/organisation/directorates/D01\" ,\n      \"inScheme\"
+        : \"http://data.food.gov.uk/codes/organisation/directorates\" ,\n      \"label\"
+        : \"Chief Executive & Directors\" ,\n      \"notation\" : \"D01\" ,\n      \"prefLabel\"
+        : \"Chief Executive & Directors\" ,\n      \"topConceptOf\" : \"http://data.food.gov.uk/codes/organisation/directorates\"
+        ,\n      \"type\" : \"http://data.food.gov.uk/def/organisation/Directorate\"\n
+        \   }\n     ,\n    \"elements\" : [ { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/02471d9be8eeb726f4840bf4c6fd4428\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2015-16 Quarter 1\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/ed2b5757-04a7-4431-ada3-ee18da130dc6\"
+        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/gifts-hospitality-2015-16-q1.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/ed2b5757-04a7-4431-ada3-ee18da130dc6\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2015-06-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/02471d9be8eeb726f4840bf4c6fd4428\"
+        ,\n      \"startDate\" : \"2015-04-01\" ,\n      \"temporal\" : \"2015-04-01/2015-06-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2015-16 Quarter 1\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/0c9eb8413007f14c69e3a4d3dd19785e\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2013-14 Quarter 4\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/2e8533c0-edcc-49b4-b830-506fe15e9ad0\"
+        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2013-14q4.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/2e8533c0-edcc-49b4-b830-506fe15e9ad0\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2014-03-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/0c9eb8413007f14c69e3a4d3dd19785e\"
+        ,\n      \"startDate\" : \"2014-01-01\" ,\n      \"temporal\" : \"2014-01-01/2014-03-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2013-14 Quarter 4\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
+        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/11fc247cf0765f9222911fa83be3bdda\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2014-15 Quarter 3\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/3b4000b0-6052-41fd-8d23-69d727f56752\"
+        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2014-15-q3.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/3b4000b0-6052-41fd-8d23-69d727f56752\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2014-12-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/11fc247cf0765f9222911fa83be3bdda\"
+        ,\n      \"startDate\" : \"2014-10-01\" ,\n      \"temporal\" : \"2014-10-01/2014-12-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2014-15 Quarter 3\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/21fece772e388f812bd913462870bdf8\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2013-14 Quarter 3\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/69f81e4b-47e3-4c5e-a4ac-3404341874ca\"
+        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2013-14q3.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/69f81e4b-47e3-4c5e-a4ac-3404341874ca\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2013-12-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/21fece772e388f812bd913462870bdf8\"
+        ,\n      \"startDate\" : \"2013-10-01\" ,\n      \"temporal\" : \"2013-10-01/2013-12-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2013-14 Quarter 3\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
+        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2c5b77a1-33c9-49a4-a3af-f4ac83bd6bbc\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2015-16 Quarter 3 (October 2015 - December 2015).\" ,\n      \"distribution\"
+        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/ea094b02-23c3-4806-88c7-428c481e6b62\"
+        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2015-16-quarter-3.csv\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2015-12-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2c5b77a1-33c9-49a4-a3af-f4ac83bd6bbc\"
+        ,\n      \"startDate\" : \"2015-10-01\" ,\n      \"temporal\" : \"2015-10-01/2015-12-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2015-16 Quarter 3\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2c698a6b39dae342917d70ea8e2c7755\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2014-15 Quarter 2\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/e840f89f-f346-4cb8-ab57-91b6001d559a\"
+        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-hosp-gifts-2014-15-q2.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/e840f89f-f346-4cb8-ab57-91b6001d559a\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2014-09-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2c698a6b39dae342917d70ea8e2c7755\"
+        ,\n      \"startDate\" : \"2014-07-01\" ,\n      \"temporal\" : \"2014-07-01/2014-09-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2014-15 Quarter 2\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2e69be1dcf9521c7c2fec4568b5f9f70\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2014-15 Quarter 4\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/c52cb7d4-7f29-4dd7-a712-fecf0c879c40\"
+        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2014-15-q4.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/c52cb7d4-7f29-4dd7-a712-fecf0c879c40\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2015-03-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/2e69be1dcf9521c7c2fec4568b5f9f70\"
+        ,\n      \"startDate\" : \"2015-01-01\" ,\n      \"temporal\" : \"2015-01-01/2015-03-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2014-15 Quarter 4\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/39b19008-adb3-4f7f-9104-d20a2a22c424\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2015-16 Quarter 4 (January 2016 - March 2016).\" ,\n      \"distribution\"
+        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/2d19ce74-c400-4d47-a9c7-e9f44cb253f4\"
+        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2015-16-quarter-4.csv\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2016-03-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/39b19008-adb3-4f7f-9104-d20a2a22c424\"
+        ,\n      \"startDate\" : \"2016-01-01\" ,\n      \"temporal\" : \"2016-01-01/2016-03-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2015-16 Quarter 4\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/3b9644b9-b0b1-43e8-88e0-7e5207990f11\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2016-17 Quarter 3 (October 2016 - December 2016).\" ,\n      \"distribution\"
+        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/7f567e23-d38c-4edd-a74e-8a28628ea006\"
+        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2016-17-quarter-3.csv\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2016-12-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/3b9644b9-b0b1-43e8-88e0-7e5207990f11\"
+        ,\n      \"startDate\" : \"2016-10-01\" ,\n      \"temporal\" : \"2016-10-01/2016-12-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2016-17 Quarter 3\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/64c45558ea8ab5ab6efd8eac05cf1a28\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2013-14 Quarter 1\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/4658dd7c-31a7-4f0c-a068-fc2a36704199\"
+        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2013-14q1.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/4658dd7c-31a7-4f0c-a068-fc2a36704199\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2013-06-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/64c45558ea8ab5ab6efd8eac05cf1a28\"
+        ,\n      \"startDate\" : \"2013-04-01\" ,\n      \"temporal\" : \"2013-04-01/2013-06-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2013-14 Quarter 1\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
+        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/706f75f3caf5d3f491ae1e14d37ab201\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2013-14 Quarter 2\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/43e73335-2650-4d8b-86a8-3354f3ac6ab1\"
+        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2013-14q2.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/43e73335-2650-4d8b-86a8-3354f3ac6ab1\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2013-09-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/706f75f3caf5d3f491ae1e14d37ab201\"
+        ,\n      \"startDate\" : \"2013-07-01\" ,\n      \"temporal\" : \"2013-07-01/2013-09-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2013-14 Quarter 2\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
+        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/752fe35f-6210-4b41-a9bf-d06188f56407\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2016-17 Quarter 1 (April 2017 - June 2017).\" ,\n      \"distribution\"
+        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/ce4eae53-dc2c-482b-89c7-c326bf830572\"
+        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2017-18-quarter-1.csv\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2017-06-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/752fe35f-6210-4b41-a9bf-d06188f56407\"
+        ,\n      \"startDate\" : \"2017-04-01\" ,\n      \"temporal\" : \"2017-04-01/2017-06-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2017-18 Quarter 1\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/9dd6d5a5-fa65-458d-939d-33c1dcb6172b\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2016-17 Quarter 2 (July 2016 - September 2016).\" ,\n      \"distribution\"
+        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/6e824fba-bf4b-4521-9efd-3a3b656ab9fa\"
+        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2016-17-quarter-2.csv\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2016-09-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/9dd6d5a5-fa65-458d-939d-33c1dcb6172b\"
+        ,\n      \"startDate\" : \"2016-07-01\" ,\n      \"temporal\" : \"2016-07-01/2016-09-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2016-17 Quarter 2\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/a85b71932cfb4b0241b7591baf667d64\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2014-15 Quarter 1\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/afdb8085-36f4-4060-ba77-b0dd269c216e\"
+        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2014-15q1.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/afdb8085-36f4-4060-ba77-b0dd269c216e\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2014-06-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/a85b71932cfb4b0241b7591baf667d64\"
+        ,\n      \"startDate\" : \"2014-04-01\" ,\n      \"temporal\" : \"2014-04-01/2014-06-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2014-15 Quarter 1\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/c6273910a48b316516ba8336cd832959\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2015-16 Quarter 2\" ,\n      \"distribution\" : { \n        \"@id\"
+        : \"http://data.food.gov.uk/catalog/data/distribution/d0e1ac12-2fbe-4e52-8f6b-ce55b9fad6be\"
+        ,\n        \"downloadURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/gifts-hospitality-2015-16-q2.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/d0e1ac12-2fbe-4e52-8f6b-ce55b9fad6be\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2015-09-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/c6273910a48b316516ba8336cd832959\"
+        ,\n      \"startDate\" : \"2015-07-01\" ,\n      \"temporal\" : \"2015-07-01/2015-09-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2015-16 Quarter 2\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/c90ea6bc-b4b4-4512-9337-7d0de5399b10\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2017-18 Quarter 3 (October 2017 - December 2017).\" ,\n      \"distribution\"
+        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/7fd86d10-80e5-44ce-942c-1a2fb1629a46\"
+        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2017-18-quarter-3.csv\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2017-12-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/c90ea6bc-b4b4-4512-9337-7d0de5399b10\"
+        ,\n      \"startDate\" : \"2017-10-01\" ,\n      \"temporal\" : \"2017-10-01/2017-12-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2017-18 Quarter 3\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/cc2c97f6-2d8f-4ec2-ba74-6d336418e7dd\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2017-18 Quarter 2 (July 2017 - September 2017).\" ,\n      \"distribution\"
+        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/d73bcf57-5034-4ccb-aa7d-fc11ef179e28\"
+        ,\n        \"accessURL\" : \"\" ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2017-18-quarter-2.csv\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2017-09-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/cc2c97f6-2d8f-4ec2-ba74-6d336418e7dd\"
+        ,\n      \"startDate\" : \"2017-07-01\" ,\n      \"temporal\" : \"2017-07-01/2017-09-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2017-18 Quarter 2\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/e7766f133c86d9121db46ed9e8d6ee4f\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2012-2013\" ,\n      \"distribution\" : { \n        \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/distribution/b26cab95-0ca5-4a04-8d7d-a5db2b676d36\"
+        ,\n        \"accessURL\" : \"https://fsa-catalogue2.s3.eu-west-2.amazonaws.com/fsa-board-directors-gifts-hosp-2012-13.csv\"
+        ,\n        \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/b26cab95-0ca5-4a04-8d7d-a5db2b676d36\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2013-03-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/e7766f133c86d9121db46ed9e8d6ee4f\"
+        ,\n      \"startDate\" : \"2012-04-01\" ,\n      \"temporal\" : \"2012-04-01/2013-03-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2012-2013\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Element\"\n
+        \   }\n    , { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/faa91a1f-de74-45eb-be9e-226a30154052\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2016-17 Quarter 1 (April 2016 - June 2016).\" ,\n      \"distribution\"
+        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/c990128f-ef7f-4a8f-8be1-40ad97807911\"
+        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2016-17-quarter-1.csv\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2016-06-30\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/faa91a1f-de74-45eb-be9e-226a30154052\"
+        ,\n      \"startDate\" : \"2016-04-01\" ,\n      \"temporal\" : \"2016-04-01/2016-06-30\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2016-17 Quarter 1\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n    , { \n      \"@id\" :
+        \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/fe00a63b-867e-4fb3-98f1-95d35b2fd2eb\"
+        ,\n      \"dataset\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n      \"description\" : \"FSA Board and directors registered gifts and
+        hospitality 2016-17 Quarter 4 (January 2017 - March 2017).\" ,\n      \"distribution\"
+        : { \n        \"@id\" : \"http://data.food.gov.uk/catalog/distribution/8df87316-0766-492d-a6e3-c776d5d43e3f\"
+        ,\n        \"downloadURL\" : \"https://fsadata.github.io/board-and-directors-registered-gifts-and-hospitality/data/fsa-board-and-directors-registered-gifts-and-hospitality-2016-17-quarter-4.csv\"
+        ,\n        \"mediaType\" : \"text/csv\" ,\n        \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \     }\n       ,\n      \"endDate\" : \"2017-03-31\" ,\n      \"identifier\"
+        : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90/element/fe00a63b-867e-4fb3-98f1-95d35b2fd2eb\"
+        ,\n      \"startDate\" : \"2017-01-01\" ,\n      \"temporal\" : \"2017-01-01/2017-03-31\"
+        ,\n      \"title\" : \"FSA Board and directors registered gifts and hospitality
+        2016-17 Quarter 4\" ,\n      \"type\" : [ \"http://vocab.epimorphics.com/def/catalog/Element\",
+        \"http://www.w3.org/ns/dcat#Dataset\" ]\n    }\n     ] ,\n    \"endDate\"
+        : \"2017-12-31\" ,\n    \"identifier\" : \"http://data.food.gov.uk/catalog/data/dataset/0cf781b6-6886-4cd1-ad68-829252b15f90\"
+        ,\n    \"issued\" : \"2014-04-01\" ,\n    \"keyword\" : [ \"gifts\", \"transparency\"
+        ] ,\n    \"keywords\" : [ \"http://data.food.gov.uk/catalog/data/keyword/gifts\",
+        \"http://data.food.gov.uk/catalog/data/keyword/transparency\" ] ,\n    \"landingPage\"
+        : \"https://data.gov.uk/dataset/fsa-board-and-directors-registered-gifts-and-hospitality\"
+        ,\n    \"license\" : { \n      \"@id\" : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
+        ,\n      \"label\" : \"Open Government Licence (v3)\" ,\n      \"notation\"
+        : \"OGLv3\" ,\n      \"prefLabel\" : \"Open Government Licence (v3)\" ,\n
+        \     \"type\" : [ \"http://creativecommons.org/ns#License\", \"http://schema.theodi.org/odrs#License\"
+        ]\n    }\n     ,\n    \"modified\" : \"2018-05-11\" ,\n    \"published\" :
+        true ,\n    \"publisher\" : \"http://www.food.gov.uk/#id\" ,\n    \"startDate\"
+        : \"2012-04-01\" ,\n    \"temporal\" : \"2012-04-01/2017-12-31\" ,\n    \"title\"
+        : \"Register of Gifts and Hospitality\" ,\n    \"type\" : \"http://vocab.epimorphics.com/def/catalog/Dataset\"\n
+        \ }\n   ]\n}\n\n"
+  recorded_at: Fri, 07 Aug 2020 12:44:59 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/load_dataset_element.yml
+++ b/test/vcr_cassettes/load_dataset_element.yml
@@ -2,79 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: http://18.202.57.165:8080/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.15.4
-      Accept:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      vary:
-      - Accept
-      x-response-id:
-      - '143'
-      cache-control:
-      - no-transform, max-age=0
-      content-type:
-      - application/json
-      content-length:
-      - '3673'
-      date:
-      - Tue, 12 May 2020 16:45:14 GMT
-      connection:
-      - close
-      server:
-      - Server
-    body:
-      encoding: UTF-8
-      string: "{ \n  \"@context\" : \"http://data.food.gov.uk/catalog/meta/context.jsonld\"
-        ,\n  \"meta\" : { \n    \"publisher\" : \"Food Standards Agency\" ,\n    \"licence\"
-        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
-        ,\n    \"documentation\" : \"http://data.food.gov.uk/catalog/doc\" ,\n    \"version\"
-        : \"0.0\" ,\n    \"comment\" : \"Status: Alpha service\" ,\n    \"hasFormat\"
-        : [ \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d.rdf\",
-        \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d.ttl\",
-        \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d.html\"
-        ]\n  }\n   ,\n  \"items\" : [ { \n    \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d\"
-        ,\n    \"dataset\" : { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7\"
-        ,\n      \"accrualPeriodicity\" : \"R/P1Y\" ,\n      \"activity\" : \"http://data.food.gov.uk/codes/organisation/activities/6-3\"
-        ,\n      \"description\" : \"A summary of data sharing agreements between
-        the FSA and other organisations.\" ,\n      \"directorate\" : \"http://data.food.gov.uk/codes/organisation/directorates/D05\"
-        ,\n      \"elements\" : [ \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d\",
-        \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/9b119dc7-cec5-4ae4-b1e2-510864a01166\"
-        ] ,\n      \"endDate\" : \"2017-12-31\" ,\n      \"identifier\" : \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7\"
-        ,\n      \"issued\" : \"2017-01-09\" ,\n      \"keyword\" : [ \"agreement\",
-        \"personal data\" ] ,\n      \"keywords\" : [ \"http://data.food.gov.uk/catalog/data/keyword/agreement\",
-        \"http://data.food.gov.uk/catalog/data/keyword/personal-data\" ] ,\n      \"landingPage\"
-        : \"http://fsadata.github.io/data-sharing-register\" ,\n      \"license\"
-        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
-        ,\n      \"modified\" : \"2018-02-09\" ,\n      \"published\" : true ,\n      \"publisher\"
-        : \"http://www.food.gov.uk/#id\" ,\n      \"startDate\" : \"2016-01-01\" ,\n
-        \     \"temporal\" : \"2016-01-01/2017-12-31\" ,\n      \"title\" : \"Data
-        Sharing Register\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Dataset\"\n
-        \   }\n     ,\n    \"description\" : \"This dataset is an abridged version
-        of the Information Management and Security Team log of Data Sharing Agreements.
-        The log is used to record, track and report on the various data sharing agreements
-        made by the FSA with other organisations to share information compliantly
-        in 2016.\" ,\n    \"distribution\" : { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956\"
-        ,\n      \"downloadURL\" : \"https://fsadata.github.io/data-sharing-register/data/data-sharing-register-for-2016.csv\"
-        ,\n      \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956\"
-        ,\n      \"mediaType\" : \"text/csv\" ,\n      \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
-        \   }\n     ,\n    \"endDate\" : \"2016-12-31\" ,\n    \"identifier\" : \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d\"
-        ,\n    \"startDate\" : \"2016-01-01\" ,\n    \"temporal\" : \"2016-01-01/2016-12-31\"
-        ,\n    \"title\" : \"Data Sharing Register for 2016\" ,\n    \"type\" : [
-        \"http://vocab.epimorphics.com/def/catalog/Element\", \"http://www.w3.org/ns/dcat#Dataset\"
-        ]\n  }\n   ]\n}\n\n"
-  recorded_at: Tue, 12 May 2020 16:45:14 GMT
-- request:
-    method: get
     uri: http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d
     body:
       encoding: US-ASCII
@@ -183,4 +110,77 @@ http_interactions:
         \"http://vocab.epimorphics.com/def/catalog/Element\", \"http://www.w3.org/ns/dcat#Dataset\"
         ]\n  }\n   ]\n}\n\n"
   recorded_at: Fri, 31 Jul 2020 07:54:47 GMT
+- request:
+    method: get
+    uri: http://18.202.57.165:8080/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      vary:
+      - Accept
+      x-response-id:
+      - '59'
+      cache-control:
+      - no-transform, max-age=0
+      content-type:
+      - application/json
+      content-length:
+      - '3673'
+      date:
+      - Fri, 07 Aug 2020 12:44:59 GMT
+      connection:
+      - close
+      server:
+      - Server
+    body:
+      encoding: UTF-8
+      string: "{ \n  \"@context\" : \"http://data.food.gov.uk/catalog/meta/context.jsonld\"
+        ,\n  \"meta\" : { \n    \"publisher\" : \"Food Standards Agency\" ,\n    \"licence\"
+        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
+        ,\n    \"documentation\" : \"http://data.food.gov.uk/catalog/doc\" ,\n    \"version\"
+        : \"0.0\" ,\n    \"comment\" : \"Status: Alpha service\" ,\n    \"hasFormat\"
+        : [ \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d.rdf\",
+        \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d.ttl\",
+        \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d.html\"
+        ]\n  }\n   ,\n  \"items\" : [ { \n    \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d\"
+        ,\n    \"dataset\" : { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7\"
+        ,\n      \"accrualPeriodicity\" : \"R/P1Y\" ,\n      \"activity\" : \"http://data.food.gov.uk/codes/organisation/activities/6-3\"
+        ,\n      \"description\" : \"A summary of data sharing agreements between
+        the FSA and other organisations.\" ,\n      \"directorate\" : \"http://data.food.gov.uk/codes/organisation/directorates/D05\"
+        ,\n      \"elements\" : [ \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d\",
+        \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/9b119dc7-cec5-4ae4-b1e2-510864a01166\"
+        ] ,\n      \"endDate\" : \"2017-12-31\" ,\n      \"identifier\" : \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7\"
+        ,\n      \"issued\" : \"2017-01-09\" ,\n      \"keyword\" : [ \"agreement\",
+        \"personal data\" ] ,\n      \"keywords\" : [ \"http://data.food.gov.uk/catalog/data/keyword/agreement\",
+        \"http://data.food.gov.uk/catalog/data/keyword/personal-data\" ] ,\n      \"landingPage\"
+        : \"http://fsadata.github.io/data-sharing-register\" ,\n      \"license\"
+        : \"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\"
+        ,\n      \"modified\" : \"2018-02-09\" ,\n      \"published\" : true ,\n      \"publisher\"
+        : \"http://www.food.gov.uk/#id\" ,\n      \"startDate\" : \"2016-01-01\" ,\n
+        \     \"temporal\" : \"2016-01-01/2017-12-31\" ,\n      \"title\" : \"Data
+        Sharing Register\" ,\n      \"type\" : \"http://vocab.epimorphics.com/def/catalog/Dataset\"\n
+        \   }\n     ,\n    \"description\" : \"This dataset is an abridged version
+        of the Information Management and Security Team log of Data Sharing Agreements.
+        The log is used to record, track and report on the various data sharing agreements
+        made by the FSA with other organisations to share information compliantly
+        in 2016.\" ,\n    \"distribution\" : { \n      \"@id\" : \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956\"
+        ,\n      \"downloadURL\" : \"https://fsadata.github.io/data-sharing-register/data/data-sharing-register-for-2016.csv\"
+        ,\n      \"identifier\" : \"http://data.food.gov.uk/catalog/data/distribution/23f65130-7026-4c84-9e1b-9b3eb1e3c956\"
+        ,\n      \"mediaType\" : \"text/csv\" ,\n      \"type\" : \"http://www.w3.org/ns/dcat#Distribution\"\n
+        \   }\n     ,\n    \"endDate\" : \"2016-12-31\" ,\n    \"identifier\" : \"http://data.food.gov.uk/catalog/data/dataset/c27423b7-775c-4220-a626-638fecd409a7/element/57bee23ec56bb56904388aad33176a5d\"
+        ,\n    \"startDate\" : \"2016-01-01\" ,\n    \"temporal\" : \"2016-01-01/2016-12-31\"
+        ,\n    \"title\" : \"Data Sharing Register for 2016\" ,\n    \"type\" : [
+        \"http://vocab.epimorphics.com/def/catalog/Element\", \"http://www.w3.org/ns/dcat#Dataset\"
+        ]\n  }\n   ]\n}\n\n"
+  recorded_at: Fri, 07 Aug 2020 12:44:59 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
The Rubocop config was rather unexpectedly missing. Added the missing
file, and then resolved the lint warnings that were generated. Most of
the warnings were resolved automatically (e.g. missing frozen-string
magic comments).

As of this commit, there are 0 unresolved Rubocop warnings