### PR TITLE
Issue/64 skip repeated content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # data-dot-food catalog browser change history
 
+## 1.1.9 - 2020-08-20 (Bogdan)
+
+- added "skip to main content" link at the top left of the page
+
 ## 1.1.6 - 2020-08-07 (Ian)
 
 - added missing .rubocop.yml

--- a/app/javascript/stylesheets/utilities.css
+++ b/app/javascript/stylesheets/utilities.css
@@ -64,3 +64,27 @@
 .header__content > *:last-child {
   margin: 0;
 }
+
+/* Skip to main content styles */
+.skip-to-content {
+  background: var(--color-white);
+  padding: 1rem;
+  z-index: 9999;
+}
+
+.off-canvas {
+  left: -999rem;
+  position: absolute;
+  top: -999rem;
+
+  @media print {
+    display: none;
+  }
+}
+
+.off-canvas--focusable {
+  &:focus {
+    left: 0;
+    top: 0;
+  }
+}

--- a/app/javascript/stylesheets/utilities.css
+++ b/app/javascript/stylesheets/utilities.css
@@ -64,27 +64,3 @@
 .header__content > *:last-child {
   margin: 0;
 }
-
-/* Skip to main content styles */
-.skip-to-content {
-  background: var(--color-white);
-  padding: 1rem;
-  z-index: 9999;
-}
-
-.off-canvas {
-  left: -999rem;
-  position: absolute;
-  top: -999rem;
-
-  @media print {
-    display: none;
-  }
-}
-
-.off-canvas--focusable {
-  &:focus {
-    left: 0;
-    top: 0;
-  }
-}

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 class Version
   MAJOR = 1
   MINOR = 1
-  PATCH = 6
+  PATCH = 9
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
 
   <body class="theme--data">
     <%= render partial: 'shared/global_cookie_message' %>
-    <a href="#featured-datasets__heading" class="skip-to-content off-canvas off-canvas--focusable">
+    <a href="#block-pagetitle" class="skip-to-content off-canvas off-canvas--focusable">
       Skip to main content
     </a>
     <div class="site js-site">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,9 @@
 
   <body class="theme--data">
     <%= render partial: 'shared/global_cookie_message' %>
+    <a href="#featured-datasets__heading" class="skip-to-content off-canvas off-canvas--focusable">
+      Skip to main content
+    </a>
     <div class="site js-site">
       <%= render partial: 'shared/gtm_noscript' %>
       <%= render partial: 'shared/page_header' %>

--- a/app/views/layouts/landing.html.erb
+++ b/app/views/layouts/landing.html.erb
@@ -25,6 +25,9 @@
 
   <body class="theme--data">
     <%= render partial: 'shared/global_cookie_message' %>
+    <a href="#featured-datasets__heading" class="skip-to-content off-canvas off-canvas--focusable">
+      Skip to main content
+    </a>
     <div class="site js-site">
       <%= render partial: 'shared/gtm_noscript' %>
       <%= render partial: 'shared/page_header' %>


### PR DESCRIPTION
This PR adds the option for the user to skip to main content via a link at the top of the page, according to issue: FoodStandardsAgency/data-dot-food/issues/64 . This link is out of view and can be accessed by going to the homepage and pressing tab once (regarding tab ordering, the link comes first)