### PR TITLE
Sentry Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # data-dot-food catalog browser change history
 
+## 1.1.11 - 2020-08-26 (Bogdan)
+
+- changed Sentry configuration so it will only report errors in production
+
 ## 1.1.6 - 2020-08-07 (Ian)
 
 - added missing .rubocop.yml

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 class Version
   MAJOR = 1
   MINOR = 1
-  PATCH = 6
+  PATCH = 11
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,4 +2,5 @@
 
 Raven.configure do |config|
   config.dsn = 'https://36b53cb8640d4b21a2342076d394e7ea:e921da4daef0454c8b3cd5551bb19410@o74279.ingest.sentry.io/2520779'
+  config.environments = %w[production]
 end


### PR DESCRIPTION
No issue to link it too, but this PR adds a configuration entry to Sentry so it will only run in production

To do:
- bump app version
- add changelog entry