### PR TITLE
Add main landmark to error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # data-dot-food catalog browser change history
 
+## 1.1.15 - 2020-09-09 (Ian)
+
+- Added `main` landmark to 404 page, to resolve warnings from Axe and Silktide
+
 ## 1.1.15 - 2020-09-97 (Ian)
 
 - Various WCAG fixes on the feedback form

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 class Version
   MAJOR = 1
   MINOR = 1
-  PATCH = 15
+  PATCH = 16
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end

--- a/app/views/exception/error_page.html.haml
+++ b/app/views/exception/error_page.html.haml
@@ -1,4 +1,4 @@
-.layout.layout--main.layout--with-no-sidebar
+%main#main-content.layout.layout--main.layout--with-no-sidebar
   .layout__container.layout__container--main
     .layout__content.layout__content--main.layout__content--header.js-content
       #block-pagetitle
@@ -17,4 +17,3 @@
 
           %p
             If this problem persists, please let us know via the feedback form.
-            


### PR DESCRIPTION
FoodStandardsAgency/data-dot-food#98
Added a missing `main` landmark element to the page