### PR TITLE
Change destination for feedback emails

### DIFF
--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -2,13 +2,13 @@
 
 # Send content of feedback form as email
 class FeedbackMailer < ApplicationMailer
-  default from: 'fsa-data-feedback@epimorphics.com'
+  default from: 'data@food.gov.uk'
 
   def feedback_email(questions_and_answers)
     @view_state = questions_and_answers
 
     now = Time.zone.now.strftime('%H:%M %d-%m-%Y')
-    mail(to: 'fsa-data-feedback@epimorphics.com',
+    mail(to: 'data@food.gov.uk',
          subject: "FSA data catalog feedback - #{now}")
   end
 end


### PR DESCRIPTION
FoodStandardsAgency/data-dot-food#111
Change the destination for data catalogue feedback so that it goes
directly to `data@food.gov.uk` instead of routing via Epimorphics.
